### PR TITLE
Make SMAC backup/restore tests work

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,9 +2,9 @@
 cache_dir = .pytest_cache
 markers =
     aws
-    aoc_aws_backup
-    aoc_aws_restore
-    aoc_aws_backup_restore
+    aoc_aws_backup_stack
+    aoc_aws_restore_stack
+    aoc_aws_backup_restore_stack
     aoc_gcp_backup
     aoc_gcp_restore
     aoc_aws_backup_restore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ansible
+boto3
 pre-commit
 pytest
 pytest-ansible

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
+  - name: amazon.aws
   - name: community.docker

--- a/tests/aoc/aws/operations/conftest.py
+++ b/tests/aoc/aws/operations/conftest.py
@@ -96,10 +96,10 @@ def pytest_addoption(parser: Parser) -> None:
         )
 
     parser.addoption(
-        f"--{AOC_AWS_RESTORE_PREFIX_OPTION}_backup_name",
+        f"--{AOC_AWS_RESTORE_PREFIX_OPTION}-backup-name",
         action="store",
         default=os.getenv(
-            f"{AOC_AWS_BACKUP_PREFIX_OPTION.upper().replace('-', '_')}_BACKUP_NAME"
+            f"{AOC_AWS_RESTORE_PREFIX_OPTION.upper().replace('-', '_')}_BACKUP_NAME"
         ),
         help="The backup folder name stored in S3 bucket",
     )


### PR DESCRIPTION
# What
This PR focuses on finishing the AoC AWS backup/restore test suite.

**Stack backup**

```
pytest --ansible-host-pattern=localhost \
--aoc-stack-deployment-name=stack-123 \
--aoc-aws-backup-iam-role-arn=iam-role-arn-123 \
--aoc-aws-backup-s3-bucket=stack-123-bucket \
--aoc-aws-backup-ssm-bucket-name=stack-123-bucket \
--aoc-aws-region=us-east-1 \
--aoc-aws-credentials-path =home/$USER/.aws/credentials \
tests/aoc/aws/operations -m aoc_aws_backup_stack
```

**Stack restore**

```
pytest --ansible-host-pattern=localhost \
--aoc-aws-restore-backup-name=stack-123-20230831 \
--aoc-aws-restore-s3-bucket=stack-123-bucket \
--aoc-aws-restore-ssm-bucket-name=stack-123-bucket \
--aoc-aws-region=us-east-1 \
--aoc-aws-credentials-path=/home/$USER/.aws/credentials \
tests/aoc/aws/operations -m aoc_aws_restore_stack
```