### PR TITLE
Use docker over podman for container runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,10 @@ python-venv-setup:
 	python3 -m venv venv
 	source venv/bin/activate && pip install -r requirements.txt
 
-podman-start-service:
-	podman system service -t 0 &
-
 collection-install:
 	ansible-galaxy collection install -r requirements.yml --force
 
-setup: python-venv-setup collection-install podman-start-service
+setup: python-venv-setup collection-install
 
 pre-commit:
 	pre-commit run --all-files --verbose --show-diff-on-failure

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All of these will be coming soon!
 Run the following commands below to setup your environment to run any tests:
 
 ```shell
-# Setup (creates python virtual environment, installs packages, starts podman service)
+# Setup (creates python virtual environment, installs packages)
 make setup
 
 # Set the necessary environment variables required by the tests

--- a/lib/containers.py
+++ b/lib/containers.py
@@ -4,7 +4,6 @@ This module provides a core class 'container engine' that other
 classes can import/use. Handles the common operations when working
 with containers to reduce duplication.
 """
-import os
 import typing
 from typing import Dict
 from typing import List
@@ -21,11 +20,6 @@ class ContainerEngine:
         :param ansible_module: the pytest ansible module fixture
         """
         self.ansible_module: BaseHostManager = ansible_module
-
-        # TODO: Revise this for other users/container runtime engines (e.g. docker)
-        os.environ[
-            "DOCKER_HOST"
-        ] = f"unix://{os.getenv('XDG_RUNTIME_DIR')}/podman/podman.sock"
 
     def registry_login(self, registry: str, username: str, password: str) -> bool:
         """Logins to the registry provided using username/password


### PR DESCRIPTION
# Change
The ops container image currently only supports docker and when using podman. You may run into issues with permissions when mounting volumes into the container/having the ops playbooks access them.

For now, the way to resolve this is to use docker directly.