### PR TITLE
Simplify pytest cli options and accessing

### DIFF
--- a/tests/aoc/aws/conftest.py
+++ b/tests/aoc/aws/conftest.py
@@ -4,9 +4,7 @@ This module contains commonly used code across all test modules.
 Majority of the functions here will be pytest fixtures.
 """
 import os
-from typing import TypedDict
 
-import pytest
 from _pytest.config.argparsing import Parser
 
 
@@ -24,24 +22,4 @@ def pytest_addoption(parser: Parser) -> None:
         action="store",
         default=os.getenv("AOC_AWS_REGION", ""),
         help="AWS region",
-    )
-
-
-class AocAwsDefaultOptions(TypedDict):
-    """Aoc aws default options typed dict."""
-
-    credentials_path: str
-    region: str
-
-
-@pytest.fixture  # type: ignore
-def aoc_aws_default_options(request: pytest.FixtureRequest) -> AocAwsDefaultOptions:
-    """AoC aws tests default pytest options fixture.
-
-    A fixture providing default options that can be used by any
-    AoC aws tests.
-    """
-    return AocAwsDefaultOptions(
-        credentials_path=request.config.getoption("aoc_aws_credentials_path"),
-        region=request.config.getoption("aoc_aws_region"),
     )

--- a/tests/aoc/aws/operations/conftest.py
+++ b/tests/aoc/aws/operations/conftest.py
@@ -4,63 +4,44 @@ This module contains commonly used code across all test modules.
 Majority of the functions here will be pytest fixtures.
 """
 import os
-from typing import TypedDict
 
-import pytest
 from _pytest.config.argparsing import Parser
-
-AOC_AWS_BACKUP_PREFIX_OPTION: str = "aoc-aws-backup"
-AOC_AWS_RESTORE_PREFIX_OPTION: str = "aoc-aws-restore"
 
 
 def pytest_addoption(parser: Parser) -> None:
     """Handles setting up options that are applicable to aoc aws."""
 
     parser.addoption(
-        f"--{AOC_AWS_BACKUP_PREFIX_OPTION}-iam-role-arn",
+        "--aoc-aws-backup-iam-role-arn",
         action="store",
-        default=os.getenv(
-            f"{AOC_AWS_BACKUP_PREFIX_OPTION.upper().replace('-', '_')}_IAM_ROLE_ARN", ""
-        ),
+        default=os.getenv("AOC_AWS_BACKUP_IAM_ROLE_ARN", ""),
         help="ARN that has permissions to perform backup operations",
     )
 
     parser.addoption(
-        f"--{AOC_AWS_BACKUP_PREFIX_OPTION}-vault-name",
+        "--aoc-aws-backup-vault-name",
         action="store",
-        default=os.getenv(
-            f"{AOC_AWS_BACKUP_PREFIX_OPTION.upper().replace('-', '_')}_VAULT_NAME",
-            "Default",
-        ),
+        default=os.getenv("AOC_AWS_BACKUP_VAULT_NAME", "Default"),
         help="Name of backup vault holding efs recovery points",
     )
 
     parser.addoption(
-        f"--{AOC_AWS_BACKUP_PREFIX_OPTION}-prefix",
+        "--aoc-aws-backup-prefix",
         action="store",
-        default=os.getenv(
-            f"{AOC_AWS_BACKUP_PREFIX_OPTION.upper().replace('-', '_')}_PREFIX",
-            "aoc-backup",
-        ),
+        default=os.getenv("AOC_AWS_BACKUP_PREFIX", "aoc-backup"),
         help="Prefix to add to the backup name",
     )
 
     for option in [
         {
-            "name": f"--{AOC_AWS_BACKUP_PREFIX_OPTION}-s3-bucket",
-            "default": os.getenv(
-                f"{AOC_AWS_BACKUP_PREFIX_OPTION.upper().replace('-', '_')}_S3_BUCKET",
-                "",
-            ),
+            "name": "--aoc-aws-backup-s3-bucket",
+            "default": os.getenv("AOC_AWS_BACKUP_S3_BUCKET", ""),
             "help": "S3 bucket name where to store backup files",
         },
         {
-            "name": f"--{AOC_AWS_RESTORE_PREFIX_OPTION}-s3-bucket",
-            "default": os.getenv(
-                f"{AOC_AWS_RESTORE_PREFIX_OPTION.upper().replace('-', '_')}_S3_BUCKET",
-                "",
-            ),
-            "help": "S3 bucket name where to store backup files",
+            "name": "--aoc-aws-restore-s3-bucket",
+            "default": os.getenv("AOC_AWS_RESTORE_S3_BUCKET", ""),
+            "help": "S3 bucket name where backup files are stored",
         },
     ]:
         parser.addoption(
@@ -72,19 +53,13 @@ def pytest_addoption(parser: Parser) -> None:
 
     for option in [
         {
-            "name": f"--{AOC_AWS_BACKUP_PREFIX_OPTION}-ssm-bucket-name",
-            "default": os.getenv(
-                f"{AOC_AWS_BACKUP_PREFIX_OPTION.upper().replace('-', '_')}_SSM_BUCKET_NAME",
-                "",
-            ),
+            "name": "--aoc-aws-backup-ssm-bucket-name",
+            "default": os.getenv("AOC_AWS_BACKUP_SSM_BUCKET_NAME", ""),
             "help": "S3 bucket where temporary config files for aws ssm are stored",
         },
         {
-            "name": f"--{AOC_AWS_RESTORE_PREFIX_OPTION}-ssm-bucket-name",
-            "default": os.getenv(
-                f"{AOC_AWS_RESTORE_PREFIX_OPTION.upper().replace('-', '_')}_SSM_BUCKET_NAME",
-                "",
-            ),
+            "name": "--aoc-aws-restore-ssm-bucket-name",
+            "default": os.getenv("AOC_AWS_RESTORE_SSM_BUCKET_NAME", ""),
             "help": "S3 bucket where temporary config files for aws ssm are stored",
         },
     ]:
@@ -96,78 +71,8 @@ def pytest_addoption(parser: Parser) -> None:
         )
 
     parser.addoption(
-        f"--{AOC_AWS_RESTORE_PREFIX_OPTION}-backup-name",
+        "--aoc-aws-restore-backup-name",
         action="store",
-        default=os.getenv(
-            f"{AOC_AWS_RESTORE_PREFIX_OPTION.upper().replace('-', '_')}_BACKUP_NAME"
-        ),
+        default=os.getenv("AOC_AWS_RESTORE_BACKUP_NAME", ""),
         help="The backup folder name stored in S3 bucket",
-    )
-
-
-class AocAwsBackupDefaultOptions(TypedDict):
-    """AoC aws backup default options typed dict."""
-
-    backup_iam_role_arn: str
-    backup_vault_name: str
-    backup_prefix: str
-    backup_s3_bucket: str
-    backup_ssm_bucket_name: str
-
-
-class AocAwsRestoreDefaultOptions(TypedDict):
-    """AoC aws restore default options typed dict."""
-
-    backup_name: str
-    backup_s3_bucket: str
-    backup_ssm_bucket_name: str
-
-
-@pytest.fixture  # type: ignore
-def aoc_aws_backup_default_options(
-    request: pytest.FixtureRequest,
-) -> AocAwsBackupDefaultOptions:
-    """AoC aws backup tests default pytest options fixture.
-
-    A fixture providing default options that can be used by any
-    AoC aws backup tests.
-    """
-    return AocAwsBackupDefaultOptions(
-        backup_iam_role_arn=request.config.getoption(
-            f"{AOC_AWS_BACKUP_PREFIX_OPTION.replace('-', '_')}_iam_role_arn"
-        ),
-        backup_vault_name=request.config.getoption(
-            f"{AOC_AWS_BACKUP_PREFIX_OPTION.replace('-', '_')}_vault_name"
-        ),
-        backup_prefix=request.config.getoption(
-            f"{AOC_AWS_BACKUP_PREFIX_OPTION.replace('-', '_')}_prefix"
-        ),
-        backup_s3_bucket=request.config.getoption(
-            f"{AOC_AWS_BACKUP_PREFIX_OPTION.replace('-', '_')}_s3_bucket"
-        ),
-        backup_ssm_bucket_name=request.config.getoption(
-            f"{AOC_AWS_BACKUP_PREFIX_OPTION.replace('-', '_')}_ssm_bucket_name"
-        ),
-    )
-
-
-@pytest.fixture  # type: ignore
-def aoc_aws_restore_default_options(
-    request: pytest.FixtureRequest,
-) -> AocAwsRestoreDefaultOptions:
-    """AoC aws restore tests default pytest options fixture.
-
-    A fixture providing default options that can be used by any
-    AoC aws restore tests.
-    """
-    return AocAwsRestoreDefaultOptions(
-        backup_name=request.config.getoption(
-            f"{AOC_AWS_RESTORE_PREFIX_OPTION.replace('-', '_')}_backup_name"
-        ),
-        backup_s3_bucket=request.config.getoption(
-            f"{AOC_AWS_RESTORE_PREFIX_OPTION.replace('-', '_')}_s3_bucket"
-        ),
-        backup_ssm_bucket_name=request.config.getoption(
-            f"{AOC_AWS_RESTORE_PREFIX_OPTION.replace('-', '_')}_ssm_bucket_name"
-        ),
     )

--- a/tests/aoc/aws/operations/test_smac_backup_restore.py
+++ b/tests/aoc/aws/operations/test_smac_backup_restore.py
@@ -10,48 +10,42 @@ from lib.aoc.aws.operations.restore import AocAwsRestore
 from lib.aoc.aws.operations.restore import AocAwsRestoreDataExtraVars
 from lib.aoc.aws.operations.restore import AocAwsRestoreDataVars
 from lib.aoc.aws.operations.restore import AocAwsRestoreStackResult
-from tests.aoc.aws.conftest import AocAwsDefaultOptions
-from tests.aoc.aws.operations.conftest import AocAwsBackupDefaultOptions
-from tests.aoc.aws.operations.conftest import AocAwsRestoreDefaultOptions
-from tests.aoc.conftest import AocDefaultOptions
 
 
 @pytest.fixture  # type: ignore
 def aoc_aws_backup_stack(
     ansible_module: BaseHostManager,
-    aoc_default_options: AocDefaultOptions,
-    aoc_aws_default_options: AocAwsDefaultOptions,
-    aoc_aws_backup_default_options: AocAwsBackupDefaultOptions,
+    pytestconfig: pytest.Config,
 ) -> AocAwsBackup:
     """Fixture returning aoc aws backup operations."""
 
     command_generator_vars: AocAwsBackupDataVars = AocAwsBackupDataVars(
-        cloud_credentials_path=aoc_aws_default_options["credentials_path"],
-        deployment_name=aoc_default_options["stack_deployment_name"],
+        cloud_credentials_path=pytestconfig.getoption("aoc_aws_credentials_path"),
+        deployment_name=pytestconfig.getoption("aoc_stack_deployment_name"),
         extra_vars=AocAwsBackupDataExtraVars(
-            aws_backup_iam_role_arn=aoc_aws_backup_default_options[
-                "backup_iam_role_arn"
-            ],
-            aws_backup_vault_name=aoc_aws_backup_default_options["backup_vault_name"],
-            aws_region=aoc_aws_default_options["region"],
-            aws_s3_bucket=aoc_aws_backup_default_options["backup_s3_bucket"],
-            aws_ssm_bucket_name=aoc_aws_backup_default_options[
-                "backup_ssm_bucket_name"
-            ],
-            backup_prefix=aoc_aws_backup_default_options["backup_prefix"],
+            aws_backup_iam_role_arn=pytestconfig.getoption(
+                "aoc_aws_backup_iam_role_arn"
+            ),
+            aws_backup_vault_name=pytestconfig.getoption("aoc_aws_backup_vault_name"),
+            aws_region=pytestconfig.getoption("aoc_aws_region"),
+            aws_s3_bucket=pytestconfig.getoption("aoc_aws_backup_s3_bucket"),
+            aws_ssm_bucket_name=pytestconfig.getoption(
+                "aoc_aws_backup_ssm_bucket_name"
+            ),
+            backup_prefix=pytestconfig.getoption("aoc_aws_backup_prefix"),
         ),
     )
 
     return AocAwsBackup(
-        aoc_version=aoc_default_options["stack_version"],
-        aoc_ops_image=aoc_default_options["ops_container_image"],
-        aoc_ops_image_tag=aoc_default_options["ops_container_image_tag"],
-        aoc_image_registry_username=aoc_default_options[
-            "ops_container_image_registry_username"
-        ],
-        aoc_image_registry_password=aoc_default_options[
-            "ops_container_image_registry_password"
-        ],
+        aoc_version=pytestconfig.getoption("aoc_version"),
+        aoc_ops_image=pytestconfig.getoption("aoc_ops_container_image"),
+        aoc_ops_image_tag=pytestconfig.getoption("aoc_ops_container_image_tag"),
+        aoc_image_registry_username=pytestconfig.getoption(
+            "aoc_ops_container_image_registry_username"
+        ),
+        aoc_image_registry_password=pytestconfig.getoption(
+            "aoc_ops_container_image_registry_password"
+        ),
         ansible_module=ansible_module,
         command_generator_vars=command_generator_vars,
     )
@@ -60,34 +54,32 @@ def aoc_aws_backup_stack(
 @pytest.fixture  # type: ignore
 def aoc_aws_restore_stack(
     ansible_module: pytest.fixture,
-    aoc_default_options: AocDefaultOptions,
-    aoc_aws_default_options: AocAwsDefaultOptions,
-    aoc_aws_restore_default_options: AocAwsRestoreDefaultOptions,
+    pytestconfig: pytest.Config,
 ) -> AocAwsRestore:
     """Fixture returning aoc aws restore operations."""
     command_generator_vars: AocAwsRestoreDataVars = AocAwsRestoreDataVars(
-        cloud_credentials_path=aoc_aws_default_options["credentials_path"],
-        deployment_name=aoc_default_options["stack_deployment_name"],
+        cloud_credentials_path=pytestconfig.getoption("aoc_aws_credentials_path"),
+        deployment_name=pytestconfig.getoption("aoc_stack_deployment_name"),
         extra_vars=AocAwsRestoreDataExtraVars(
-            aws_backup_name=aoc_aws_restore_default_options["backup_name"],
-            aws_region=aoc_aws_default_options["region"],
-            aws_s3_bucket=aoc_aws_restore_default_options["backup_s3_bucket"],
-            aws_ssm_bucket_name=aoc_aws_restore_default_options[
-                "backup_ssm_bucket_name"
-            ],
+            aws_backup_name=pytestconfig.getoption("aoc_aws_backup_vault_name"),
+            aws_region=pytestconfig.getoption("aoc_aws_region"),
+            aws_s3_bucket=pytestconfig.getoption("aoc_aws_backup_s3_bucket"),
+            aws_ssm_bucket_name=pytestconfig.getoption(
+                "aoc_aws_backup_ssm_bucket_name"
+            ),
         ),
     )
 
     return AocAwsRestore(
-        aoc_version=aoc_default_options["stack_version"],
-        aoc_ops_image=aoc_default_options["ops_container_image"],
-        aoc_ops_image_tag=aoc_default_options["ops_container_image_tag"],
-        aoc_image_registry_username=aoc_default_options[
-            "ops_container_image_registry_username"
-        ],
-        aoc_image_registry_password=aoc_default_options[
-            "ops_container_image_registry_password"
-        ],
+        aoc_version=pytestconfig.getoption("aoc_version"),
+        aoc_ops_image=pytestconfig.getoption("aoc_ops_container_image"),
+        aoc_ops_image_tag=pytestconfig.getoption("aoc_ops_container_image_tag"),
+        aoc_image_registry_username=pytestconfig.getoption(
+            "aoc_ops_container_image_registry_username"
+        ),
+        aoc_image_registry_password=pytestconfig.getoption(
+            "aoc_ops_container_image_registry_password"
+        ),
         ansible_module=ansible_module,
         command_generator_vars=command_generator_vars,
     )

--- a/tests/aoc/conftest.py
+++ b/tests/aoc/conftest.py
@@ -4,9 +4,7 @@ This module contains commonly used code across all test modules.
 Majority of the functions here will be pytest fixtures.
 """
 import os
-from typing import TypedDict
 
-import pytest
 from _pytest.config.argparsing import Parser
 
 
@@ -64,36 +62,4 @@ def pytest_addoption(parser: Parser) -> None:
         action="store",
         default=os.getenv("AOC_STACK_DEPLOYMENT_NAME", ""),
         help="AoC stack deployment name",
-    )
-
-
-class AocDefaultOptions(TypedDict):
-    """AoC default options typed dict."""
-
-    ops_container_image: str
-    ops_container_image_tag: str
-    ops_container_image_registry_username: str
-    ops_container_image_registry_password: str
-    stack_deployment_name: str
-    stack_version: str
-
-
-@pytest.fixture  # type: ignore
-def aoc_default_options(request) -> AocDefaultOptions:
-    """AoC tests default pytest options fixture.
-
-    A fixture providing default options that can be used by
-    any AoC tests.
-    """
-    return AocDefaultOptions(
-        ops_container_image=request.config.getoption("aoc_ops_container_image"),
-        ops_container_image_tag=request.config.getoption("aoc_ops_container_image_tag"),
-        ops_container_image_registry_username=request.config.getoption(
-            "aoc_ops_container_image_registry_username"
-        ),
-        ops_container_image_registry_password=request.config.getoption(
-            "aoc_ops_container_image_registry_password"
-        ),
-        stack_deployment_name=request.config.getoption("aoc_stack_deployment_name"),
-        stack_version=request.config.getoption("aoc_version"),
     )

--- a/tests/aoc/gcp/operations/test_smac_backup_restore.py
+++ b/tests/aoc/gcp/operations/test_smac_backup_restore.py
@@ -6,26 +6,25 @@ from lib.aoc.gcp.operations.backup import AocGcpBackup
 from lib.aoc.gcp.operations.backup import AocGcpBackupDataVars
 from lib.aoc.gcp.operations.restore import AocGcpRestore
 from lib.aoc.gcp.operations.restore import AocGcpRestoreDataVars
-from tests.aoc.conftest import AocDefaultOptions
 
 
 @pytest.fixture  # type: ignore
 def aoc_gcp_backup(
-    ansible_module: BaseHostManager, aoc_default_options: AocDefaultOptions
+    ansible_module: BaseHostManager, pytestconfig: pytest.Config
 ) -> AocGcpBackup:
     """Fixture returning aoc gcp backup operations."""
     command_generator_vars: AocGcpBackupDataVars = AocGcpBackupDataVars(todo="todo")
 
     return AocGcpBackup(
-        aoc_version=aoc_default_options["stack_version"],
-        aoc_ops_image=aoc_default_options["ops_container_image"],
-        aoc_ops_image_tag=aoc_default_options["ops_container_image_tag"],
-        aoc_image_registry_username=aoc_default_options[
-            "ops_container_image_registry_username"
-        ],
-        aoc_image_registry_password=aoc_default_options[
-            "ops_container_image_registry_password"
-        ],
+        aoc_version=pytestconfig.getoption("aoc_version"),
+        aoc_ops_image=pytestconfig.getoption("aoc_ops_container_image"),
+        aoc_ops_image_tag=pytestconfig.getoption("aoc_ops_container_image_tag"),
+        aoc_image_registry_username=pytestconfig.getoption(
+            "aoc_ops_container_image_registry_username"
+        ),
+        aoc_image_registry_password=pytestconfig.getoption(
+            "aoc_ops_container_image_registry_password"
+        ),
         ansible_module=ansible_module,
         command_generator_vars=command_generator_vars,
     )
@@ -33,21 +32,21 @@ def aoc_gcp_backup(
 
 @pytest.fixture  # type: ignore
 def aoc_gcp_restore(
-    ansible_module: pytest.fixture, aoc_default_options: AocDefaultOptions
+    ansible_module: pytest.fixture, pytestconfig: pytest.Config
 ) -> AocGcpRestore:
     """Fixture returning aoc gcp restore operations."""
     command_generator_vars: AocGcpRestoreDataVars = AocGcpRestoreDataVars(todo="todo")
 
     return AocGcpRestore(
-        aoc_version=aoc_default_options["stack_version"],
-        aoc_ops_image=aoc_default_options["ops_container_image"],
-        aoc_ops_image_tag=aoc_default_options["ops_container_image_tag"],
-        aoc_image_registry_username=aoc_default_options[
-            "ops_container_image_registry_username"
-        ],
-        aoc_image_registry_password=aoc_default_options[
-            "ops_container_image_registry_password"
-        ],
+        aoc_version=pytestconfig.getoption("aoc_version"),
+        aoc_ops_image=pytestconfig.getoption("aoc_ops_container_image"),
+        aoc_ops_image_tag=pytestconfig.getoption("aoc_ops_container_image_tag"),
+        aoc_image_registry_username=pytestconfig.getoption(
+            "aoc_ops_container_image_registry_username"
+        ),
+        aoc_image_registry_password=pytestconfig.getoption(
+            "aoc_ops_container_image_registry_password"
+        ),
         ansible_module=ansible_module,
         command_generator_vars=command_generator_vars,
     )


### PR DESCRIPTION
# Change
Previously fixtures were created to be consumed by tests to access the cli options "input for test cases". Instead of creating new fixtures for each type of cli options added. Can make use of the [pytestconfig](https://docs.pytest.org/en/6.2.x/reference.html#std-fixture-pytestconfig) fixture provided out of the box with pytest. This commit removes the custom fixtures created and accesses the test input data using the pytestconfig fixture.